### PR TITLE
Local state and optional state

### DIFF
--- a/Modules/Architecture/Architecture/Core/Reducer.swift
+++ b/Modules/Architecture/Architecture/Core/Reducer.swift
@@ -34,6 +34,13 @@ public struct Reducer<StateType, ActionType> {
     ) -> Reducer<StateType, GlobalAction> {
         return self.pullback(state: \StateType.self, action: action)
     }
+
+    public var optional: Reducer<StateType?, ActionType> {
+        .init { state, action in
+            guard state != nil else { return [] }
+            return self.reduce(&state!, action)
+        }
+    }
 }
 
 public func combine<State, Action>(

--- a/Modules/Onboarding/Onboarding/Common/OnboardingState.swift
+++ b/Modules/Onboarding/Onboarding/Common/OnboardingState.swift
@@ -3,42 +3,15 @@ import Models
 import Architecture
 import Utils
 
-public struct LocalOnboardingState: Equatable {
-    internal var email: String = ""
-    internal var password: String = ""
-    
-    public init() {
-    }
-}
-
 public struct OnboardingState: Equatable {
     public var user: Loadable<User>
     public var route: RoutePath
-    public var localOnboardingState: LocalOnboardingState
-    
-    public init(user: Loadable<User>, route: RoutePath, localOnboardingState: LocalOnboardingState) {
+
+    internal var email: String = ""
+    internal var password: String = ""
+
+    public init(user: Loadable<User>, route: RoutePath) {
         self.user = user
         self.route = route
-        self.localOnboardingState = localOnboardingState
-    }
-}
-
-extension OnboardingState {
-    internal var email: String {
-        get {
-            localOnboardingState.email
-        }
-        set {
-            localOnboardingState.email = newValue
-        }
-    }
-    
-    internal var password: String {
-        get {
-            localOnboardingState.password
-        }
-        set {
-            localOnboardingState.password = newValue
-        }
     }
 }

--- a/Modules/Timer/Timer.xcodeproj/project.pbxproj
+++ b/Modules/Timer/Timer.xcodeproj/project.pbxproj
@@ -60,7 +60,6 @@
 		AC42284A2456EC5C00DD8AB3 /* WheelBackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC4228492456EC5C00DD8AB3 /* WheelBackgroundView.swift */; };
 		AC42284C245720E700DD8AB3 /* Wheel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC42284B245720E700DD8AB3 /* Wheel.swift */; };
 		AC42284F24572F4B00DD8AB3 /* ClockDial.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC42284E24572F4B00DD8AB3 /* ClockDial.swift */; };
-		AC823A01245874BB0078574D /* StartEditSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC8239FF245874BB0078574D /* StartEditSelector.swift */; };
 		AC823A05245ADA950078574D /* EditDurationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC823A04245ADA950078574D /* EditDurationView.swift */; };
 		ACAA58262433A7ED003FDECA /* RunningTimeEntryCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACAA58202433A7ED003FDECA /* RunningTimeEntryCoordinator.swift */; };
 		ACAA58272433A7ED003FDECA /* RunningTimeEntryState.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACAA58212433A7ED003FDECA /* RunningTimeEntryState.swift */; };
@@ -168,7 +167,6 @@
 		AC4228492456EC5C00DD8AB3 /* WheelBackgroundView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WheelBackgroundView.swift; sourceTree = "<group>"; };
 		AC42284B245720E700DD8AB3 /* Wheel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Wheel.swift; sourceTree = "<group>"; };
 		AC42284E24572F4B00DD8AB3 /* ClockDial.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClockDial.swift; sourceTree = "<group>"; };
-		AC8239FF245874BB0078574D /* StartEditSelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartEditSelector.swift; sourceTree = "<group>"; };
 		AC823A04245ADA950078574D /* EditDurationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditDurationView.swift; sourceTree = "<group>"; };
 		ACAA58202433A7ED003FDECA /* RunningTimeEntryCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RunningTimeEntryCoordinator.swift; sourceTree = "<group>"; };
 		ACAA58212433A7ED003FDECA /* RunningTimeEntryState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RunningTimeEntryState.swift; sourceTree = "<group>"; };
@@ -395,7 +393,6 @@
 				8C509D182412644300B6DF30 /* StartEditFeature.swift */,
 				8C509D1224125AB500B6DF30 /* StartEditCoordinator.swift */,
 				8C008FD12409407B000A0C32 /* StartEditReducer.swift */,
-				AC8239FF245874BB0078574D /* StartEditSelector.swift */,
 				34C93C072453387300024F06 /* DateTimePickMode.swift */,
 			);
 			path = StartEdit;
@@ -775,7 +772,6 @@
 				ACAA58322434A1EE003FDECA /* RunningTimeEntryViewController.swift in Sources */,
 				8CE495A62434B3E2008ABE48 /* DummyLabelCell.swift in Sources */,
 				8C2517892403C27200BAD4B5 /* TimeEntryCell.swift in Sources */,
-				AC823A01245874BB0078574D /* StartEditSelector.swift in Sources */,
 				CC03C2782448AE1B0071FA55 /* ProjectAction.swift in Sources */,
 				346B6A5B246EB7CC00A76A1E /* UpdateAutocompleteSuggestionsEffect.swift in Sources */,
 				8C509D202412874100B6DF30 /* TimeEntriesSelector.swift in Sources */,

--- a/Modules/Timer/Timer.xcodeproj/project.pbxproj
+++ b/Modules/Timer/Timer.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		8C509D252412879200B6DF30 /* DayViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C509D242412879200B6DF30 /* DayViewModel.swift */; };
 		8CB54533240E7DA100154473 /* TimeEntriesLogViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CB54532240E7DA100154473 /* TimeEntriesLogViewController.swift */; };
 		8CB54535240EA67400154473 /* StartEditState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CB54534240EA67400154473 /* StartEditState.swift */; };
+		8CD1B4B32477CBFF00FB62BF /* TimerReducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CD1B4B22477CBFF00FB62BF /* TimerReducer.swift */; };
 		8CE32669243601D500C6C014 /* StartEditInputAccessoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CE32668243601D500C6C014 /* StartEditInputAccessoryView.swift */; };
 		8CE495A62434B3E2008ABE48 /* DummyLabelCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CE495A52434B3E2008ABE48 /* DummyLabelCell.swift */; };
 		AC0131B3246AEF6000C42D39 /* DurationTextFieldInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC0131B2246AEF6000C42D39 /* DurationTextFieldInfo.swift */; };
@@ -159,6 +160,7 @@
 		8CAF7AD924581A41006B961D /* TimerTests-Shared.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "TimerTests-Shared.xcconfig"; sourceTree = "<group>"; };
 		8CB54532240E7DA100154473 /* TimeEntriesLogViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeEntriesLogViewController.swift; sourceTree = "<group>"; };
 		8CB54534240EA67400154473 /* StartEditState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartEditState.swift; sourceTree = "<group>"; };
+		8CD1B4B22477CBFF00FB62BF /* TimerReducer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerReducer.swift; sourceTree = "<group>"; };
 		8CE32668243601D500C6C014 /* StartEditInputAccessoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartEditInputAccessoryView.swift; sourceTree = "<group>"; };
 		8CE495A52434B3E2008ABE48 /* DummyLabelCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DummyLabelCell.swift; sourceTree = "<group>"; };
 		AC0131B2246AEF6000C42D39 /* DurationTextFieldInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DurationTextFieldInfo.swift; sourceTree = "<group>"; };
@@ -408,6 +410,7 @@
 				8C509D0D2412567900B6DF30 /* TimerAction.swift */,
 				8C509D1A241264A200B6DF30 /* TimerCoordinator.swift */,
 				ACAA585C24378106003FDECA /* SimpleBottomSheet.swift */,
+				8CD1B4B22477CBFF00FB62BF /* TimerReducer.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -757,6 +760,7 @@
 				8CE32669243601D500C6C014 /* StartEditInputAccessoryView.swift in Sources */,
 				8C008FC424090C85000A0C32 /* StartEditViewController.swift in Sources */,
 				CC03C2802448AF0A0071FA55 /* EditableProject.swift in Sources */,
+				8CD1B4B32477CBFF00FB62BF /* TimerReducer.swift in Sources */,
 				CC5D320D24657CC5005A1837 /* Cap.swift in Sources */,
 				8C509D252412879200B6DF30 /* DayViewModel.swift in Sources */,
 				ACAA582A2433A7ED003FDECA /* RunningTimeEntryReducer.swift in Sources */,

--- a/Modules/Timer/Timer/Common/TimerCoordinator.swift
+++ b/Modules/Timer/Timer/Common/TimerCoordinator.swift
@@ -8,19 +8,21 @@ public final class TimerCoordinator: BaseCoordinator {
     private let timeLogCoordinator: TimeEntriesLogCoordinator
     private let startEditCoordinator: StartEditCoordinator
     private let runningTimeEntryCoordinator: RunningTimeEntryCoordinator
-    private let projectCoordinator: ProjectCoordinator
+//    private let projectCoordinator: ProjectCoordinator
 
     public init(
         store: Store<TimerState, TimerAction>,
         timeLogCoordinator: TimeEntriesLogCoordinator,
         startEditCoordinator: StartEditCoordinator,
-        runningTimeEntryCoordinator: RunningTimeEntryCoordinator,
-        projectCoordinator: ProjectCoordinator) {
+        runningTimeEntryCoordinator: RunningTimeEntryCoordinator
+//        ,
+//        projectCoordinator: ProjectCoordinator
+    ) {
         self.store = store
         self.timeLogCoordinator = timeLogCoordinator
         self.startEditCoordinator = startEditCoordinator
         self.runningTimeEntryCoordinator = runningTimeEntryCoordinator
-        self.projectCoordinator = projectCoordinator
+//        self.projectCoordinator = projectCoordinator
     }
 
     public override func start() {

--- a/Modules/Timer/Timer/Common/TimerReducer.swift
+++ b/Modules/Timer/Timer/Common/TimerReducer.swift
@@ -6,13 +6,19 @@ let timerReducer = Reducer<TimerState, TimerAction> { state, action in
     switch action {
 
     case let .timeLog(.timeEntryTapped(timeEntryId)):
-        state.editableTimeEntry = EditableTimeEntry.fromSingle(state.entities.timeEntries[timeEntryId]!)
+        state.startEditState = StartEditState(
+            entities: state.entities,
+            editableTimeEntry: EditableTimeEntry.fromSingle(state.entities.timeEntries[timeEntryId]!)
+        )
         return []
 
     case let .timeLog(.timeEntryGroupTapped(timeEntryIds)):
-        state.editableTimeEntry = EditableTimeEntry.fromGroup(
-            ids: timeEntryIds,
-            groupSample: state.entities.timeEntries[timeEntryIds.first!]!
+        state.startEditState = StartEditState(
+            entities: state.entities,
+            editableTimeEntry: EditableTimeEntry.fromGroup(
+                ids: timeEntryIds,
+                groupSample: state.entities.timeEntries[timeEntryIds.first!]!
+            )
         )
         return []
 
@@ -24,19 +30,45 @@ let timerReducer = Reducer<TimerState, TimerAction> { state, action in
             guard let runningTimeEntry = state.entities.timeEntries[runningTimeEntryId]
                 else { return [] }
 
-            state.editableTimeEntry = EditableTimeEntry.fromSingle(runningTimeEntry)
+            state.startEditState = StartEditState(
+                entities: state.entities,
+                editableTimeEntry: EditableTimeEntry.fromSingle(runningTimeEntry)
+            )
             return []
         }
 
         guard case let Loadable.loaded(user) = state.user else { return [] }
-        state.editableTimeEntry = EditableTimeEntry.empty(workspaceId: user.defaultWorkspace)
+        state.startEditState =  StartEditState(
+            entities: state.entities,
+            editableTimeEntry: EditableTimeEntry.empty(workspaceId: user.defaultWorkspace)
+        )
 
         return []
 
     case .runningTimeEntry:
         return []
 
-    case .startEdit, .project:
+    case let .startEdit(.timeEntryStarted(startedTimeEntry, stoppedTimeEntry)):
+        state.entities.timeEntries[startedTimeEntry.id] = startedTimeEntry
+        if let stoppedTimeEntry = stoppedTimeEntry {
+            state.entities.timeEntries[stoppedTimeEntry.id] = stoppedTimeEntry
+        }
+        state.startEditState = nil
+        return []
+
+    case let .startEdit(.timeEntryUpdated(timeEntry)):
+        state.entities.timeEntries[timeEntry.id] = timeEntry
+        state.startEditState = nil
+        return []
+
+    case .startEdit(.closeButtonTapped), .startEdit(.dialogDismissed):
+        state.startEditState = nil
+        return []
+
+    case .startEdit:
+        return []
+
+    case .project:
         return []
     }
 }

--- a/Modules/Timer/Timer/Common/TimerReducer.swift
+++ b/Modules/Timer/Timer/Common/TimerReducer.swift
@@ -1,0 +1,24 @@
+import Foundation
+import Architecture
+
+let timerReducer = Reducer<TimerState, TimerAction> { state, action in
+    switch action {
+
+    case let .timeLog(.timeEntryTapped(timeEntryId)):
+        state.editableTimeEntry = EditableTimeEntry.fromSingle(state.entities.timeEntries[timeEntryId]!)
+        return []
+
+    case let .timeLog(.timeEntryGroupTapped(timeEntryIds)):
+        state.editableTimeEntry = EditableTimeEntry.fromGroup(
+            ids: timeEntryIds,
+            groupSample: state.entities.timeEntries[timeEntryIds.first!]!
+        )
+        return []
+
+    case .timeLog:
+        return []
+
+    case .startEdit, .runningTimeEntry, .project:
+        return []
+    }
+}

--- a/Modules/Timer/Timer/Common/TimerReducer.swift
+++ b/Modules/Timer/Timer/Common/TimerReducer.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Architecture
+import Models
 
 let timerReducer = Reducer<TimerState, TimerAction> { state, action in
     switch action {
@@ -18,7 +19,24 @@ let timerReducer = Reducer<TimerState, TimerAction> { state, action in
     case .timeLog:
         return []
 
-    case .startEdit, .runningTimeEntry, .project:
+    case .runningTimeEntry(.cardTapped):
+        if let runningTimeEntryId = runningTimeEntry(state.entities)?.id {
+            guard let runningTimeEntry = state.entities.timeEntries[runningTimeEntryId]
+                else { return [] }
+
+            state.editableTimeEntry = EditableTimeEntry.fromSingle(runningTimeEntry)
+            return []
+        }
+
+        guard case let Loadable.loaded(user) = state.user else { return [] }
+        state.editableTimeEntry = EditableTimeEntry.empty(workspaceId: user.defaultWorkspace)
+
+        return []
+
+    case .runningTimeEntry:
+        return []
+
+    case .startEdit, .project:
         return []
     }
 }

--- a/Modules/Timer/Timer/Common/TimerState.swift
+++ b/Modules/Timer/Timer/Common/TimerState.swift
@@ -2,31 +2,24 @@ import Foundation
 import Models
 import Utils
 
-public struct LocalTimerState: Equatable {
+public struct TimerState: Equatable {
+    public var user: Loadable<User>
+    public var entities: TimeLogEntities
+
     internal var editableTimeEntry: EditableTimeEntry?
     internal var expandedGroups: Set<Int> = Set<Int>()
     internal var entriesPendingDeletion = Set<Int64>()
     internal var autocompleteSuggestions: [AutocompleteSuggestion] = []
     internal var dateTimePickMode: DateTimePickMode = .none
     internal var cursorPosition: Int = 0
-    
-    public init() {
-    }
-}
 
-public struct TimerState: Equatable {
-    public var user: Loadable<User>
-    public var entities: TimeLogEntities
-    public var localTimerState: LocalTimerState
-    
-    public init(user: Loadable<User>, entities: TimeLogEntities, localTimerState: LocalTimerState) {
+    public init(user: Loadable<User>, entities: TimeLogEntities) {
         self.user = user
         self.entities = entities
-        self.localTimerState = localTimerState
     }
 }
 
-extension LocalTimerState {
+extension TimerState {
     public func isEditingGroup() -> Bool {
         guard let numberOfEntriesBeingEdited = editableTimeEntry?.ids.count else { return false }
         return numberOfEntriesBeingEdited > 1
@@ -39,16 +32,16 @@ extension TimerState {
         get {
             TimeEntriesLogState(
                 entities: entities,
-                expandedGroups: localTimerState.expandedGroups,
-                editableTimeEntry: localTimerState.editableTimeEntry,
-                entriesPendingDeletion: localTimerState.entriesPendingDeletion
+                expandedGroups: expandedGroups,
+                editableTimeEntry: editableTimeEntry,
+                entriesPendingDeletion: entriesPendingDeletion
             )
         }
         set {
             entities = newValue.entities
-            localTimerState.expandedGroups = newValue.expandedGroups
-            localTimerState.editableTimeEntry = newValue.editableTimeEntry
-            localTimerState.entriesPendingDeletion = newValue.entriesPendingDeletion
+            expandedGroups = newValue.expandedGroups
+            editableTimeEntry = newValue.editableTimeEntry
+            entriesPendingDeletion = newValue.entriesPendingDeletion
         }
     }
     
@@ -57,19 +50,19 @@ extension TimerState {
             StartEditState(
                 user: user,
                 entities: entities,
-                editableTimeEntry: localTimerState.editableTimeEntry,
-                autocompleteSuggestions: localTimerState.autocompleteSuggestions,
-                dateTimePickMode: localTimerState.dateTimePickMode,
-                cursorPosition: localTimerState.cursorPosition
+                editableTimeEntry: editableTimeEntry,
+                autocompleteSuggestions: autocompleteSuggestions,
+                dateTimePickMode: dateTimePickMode,
+                cursorPosition: cursorPosition
             )
         }
         set {
             user = newValue.user
             entities = newValue.entities
-            localTimerState.editableTimeEntry = newValue.editableTimeEntry
-            localTimerState.autocompleteSuggestions = newValue.autocompleteSuggestions
-            localTimerState.dateTimePickMode = newValue.dateTimePickMode
-            localTimerState.cursorPosition = newValue.cursorPosition
+            editableTimeEntry = newValue.editableTimeEntry
+            autocompleteSuggestions = newValue.autocompleteSuggestions
+            dateTimePickMode = newValue.dateTimePickMode
+            cursorPosition = newValue.cursorPosition
         }
     }
 
@@ -78,26 +71,26 @@ extension TimerState {
             RunningTimeEntryState(
                 user: user,
                 entities: entities,
-                editableTimeEntry: localTimerState.editableTimeEntry
+                editableTimeEntry: editableTimeEntry
             )
         }
         set {
             user = newValue.user
             entities = newValue.entities
-            localTimerState.editableTimeEntry = newValue.editableTimeEntry
+            editableTimeEntry = newValue.editableTimeEntry
         }
     }
     
     internal var projectState: ProjectState {
         get {
             ProjectState(
-                editableProject: localTimerState.editableTimeEntry?.editableProject,
+                editableProject: editableTimeEntry?.editableProject,
                 projects: entities.projects
             )
         }
         set {
             entities.projects = newValue.projects
-            guard var timeEntry = localTimerState.editableTimeEntry else { return }
+            guard var timeEntry = editableTimeEntry else { return }
             timeEntry.editableProject = newValue.editableProject
         }
     }

--- a/Modules/Timer/Timer/Common/TimerState.swift
+++ b/Modules/Timer/Timer/Common/TimerState.swift
@@ -45,7 +45,6 @@ extension TimerState {
     internal var startEditState: StartEditState {
         get {
             StartEditState(
-                user: user,
                 entities: entities,
                 editableTimeEntry: editableTimeEntry,
                 autocompleteSuggestions: autocompleteSuggestions,
@@ -54,7 +53,6 @@ extension TimerState {
             )
         }
         set {
-            user = newValue.user
             entities = newValue.entities
             editableTimeEntry = newValue.editableTimeEntry
             autocompleteSuggestions = newValue.autocompleteSuggestions

--- a/Modules/Timer/Timer/Common/TimerState.swift
+++ b/Modules/Timer/Timer/Common/TimerState.swift
@@ -7,11 +7,7 @@ public struct TimerState: Equatable {
     public var entities: TimeLogEntities
 
     private var _timeEntriesLogState: TimeEntriesLogState
-
-    internal var editableTimeEntry: EditableTimeEntry?
-    internal var autocompleteSuggestions: [AutocompleteSuggestion] = []
-    internal var dateTimePickMode: DateTimePickMode = .none
-    internal var cursorPosition: Int = 0
+    private var _startEditState: StartEditState?
 
     public init(user: Loadable<User>, entities: TimeLogEntities) {
         self.user = user
@@ -23,7 +19,7 @@ public struct TimerState: Equatable {
 
 extension TimerState {
     public func isEditingGroup() -> Bool {
-        guard let numberOfEntriesBeingEdited = editableTimeEntry?.ids.count else { return false }
+        guard let numberOfEntriesBeingEdited = _startEditState?.editableTimeEntry.ids.count else { return false }
         return numberOfEntriesBeingEdited > 1
     }
 }
@@ -42,22 +38,20 @@ extension TimerState {
         }
     }
     
-    internal var startEditState: StartEditState {
+    internal var startEditState: StartEditState? {
         get {
-            StartEditState(
-                entities: entities,
-                editableTimeEntry: editableTimeEntry,
-                autocompleteSuggestions: autocompleteSuggestions,
-                dateTimePickMode: dateTimePickMode,
-                cursorPosition: cursorPosition
-            )
+            if _startEditState == nil {
+                return nil
+            }
+
+            var copy = _startEditState!
+            copy.entities = entities
+            return copy
         }
         set {
+            _startEditState = newValue
+            guard let newValue = newValue else { return }
             entities = newValue.entities
-            editableTimeEntry = newValue.editableTimeEntry
-            autocompleteSuggestions = newValue.autocompleteSuggestions
-            dateTimePickMode = newValue.dateTimePickMode
-            cursorPosition = newValue.cursorPosition
         }
     }
 

--- a/Modules/Timer/Timer/Common/TimerState.swift
+++ b/Modules/Timer/Timer/Common/TimerState.swift
@@ -76,17 +76,17 @@ extension TimerState {
         }
     }
     
-    internal var projectState: ProjectState {
-        get {
-            ProjectState(
-                editableProject: editableTimeEntry?.editableProject,
-                projects: entities.projects
-            )
-        }
-        set {
-            entities.projects = newValue.projects
-            guard var timeEntry = editableTimeEntry else { return }
-            timeEntry.editableProject = newValue.editableProject
-        }
-    }
+//    internal var projectState: ProjectState {
+//        get {
+//            ProjectState(
+//                editableProject: editableTimeEntry?.editableProject,
+//                projects: entities.projects
+//            )
+//        }
+//        set {
+//            entities.projects = newValue.projects
+//            guard var timeEntry = editableTimeEntry else { return }
+//            timeEntry.editableProject = newValue.editableProject
+//        }
+//    }
 }

--- a/Modules/Timer/Timer/Common/TimerState.swift
+++ b/Modules/Timer/Timer/Common/TimerState.swift
@@ -67,14 +67,12 @@ extension TimerState {
         get {
             RunningTimeEntryState(
                 user: user,
-                entities: entities,
-                editableTimeEntry: editableTimeEntry
+                entities: entities
             )
         }
         set {
             user = newValue.user
             entities = newValue.entities
-            editableTimeEntry = newValue.editableTimeEntry
         }
     }
     

--- a/Modules/Timer/Timer/Common/TimerState.swift
+++ b/Modules/Timer/Timer/Common/TimerState.swift
@@ -6,9 +6,9 @@ public struct TimerState: Equatable {
     public var user: Loadable<User>
     public var entities: TimeLogEntities
 
+    private var _timeEntriesLogState: TimeEntriesLogState
+
     internal var editableTimeEntry: EditableTimeEntry?
-    internal var expandedGroups: Set<Int> = Set<Int>()
-    internal var entriesPendingDeletion = Set<Int64>()
     internal var autocompleteSuggestions: [AutocompleteSuggestion] = []
     internal var dateTimePickMode: DateTimePickMode = .none
     internal var cursorPosition: Int = 0
@@ -16,6 +16,8 @@ public struct TimerState: Equatable {
     public init(user: Loadable<User>, entities: TimeLogEntities) {
         self.user = user
         self.entities = entities
+
+        _timeEntriesLogState = TimeEntriesLogState(entities: entities)
     }
 }
 
@@ -30,18 +32,13 @@ extension TimerState {
     
     internal var timeLogState: TimeEntriesLogState {
         get {
-            TimeEntriesLogState(
-                entities: entities,
-                expandedGroups: expandedGroups,
-                editableTimeEntry: editableTimeEntry,
-                entriesPendingDeletion: entriesPendingDeletion
-            )
+            var copy = _timeEntriesLogState
+            copy.entities = entities
+            return copy
         }
         set {
+            _timeEntriesLogState = newValue
             entities = newValue.entities
-            expandedGroups = newValue.expandedGroups
-            editableTimeEntry = newValue.editableTimeEntry
-            entriesPendingDeletion = newValue.entriesPendingDeletion
         }
     }
     

--- a/Modules/Timer/Timer/Running/RunningTimeEntryReducer.swift
+++ b/Modules/Timer/Timer/Running/RunningTimeEntryReducer.swift
@@ -9,20 +9,6 @@ import OtherServices
 func createRunningTimeEntryReducer(repository: TimeLogRepository, time: Time) -> Reducer<RunningTimeEntryState, RunningTimeEntryAction> {
     return Reducer { state, action in
         switch action {
-        case .cardTapped:
-            if let runningTimeEntryId = runningTimeEntryViewModelSelector(state)?.id {
-                guard let runningTimeEntry = state.entities.timeEntries[runningTimeEntryId]
-                else { return [] }
-
-                state.editableTimeEntry = EditableTimeEntry.fromSingle(runningTimeEntry)
-                return []
-            }
-
-            guard case let Loadable.loaded(user) = state.user else { return [] }
-            state.editableTimeEntry = EditableTimeEntry.empty(workspaceId: user.defaultWorkspace)
-
-            return []
-
         case .stopButtonTapped:
             guard var runningTimeEntry = state.runningTimeEntry else { return [] }
             runningTimeEntry.duration = time.now().timeIntervalSince(runningTimeEntry.start)
@@ -43,6 +29,9 @@ func createRunningTimeEntryReducer(repository: TimeLogRepository, time: Time) ->
 
         case let .setError(error):
             fatalError(error.description)
+
+        case .cardTapped:
+            return []
         }
     }
 }

--- a/Modules/Timer/Timer/Running/RunningTimeEntrySelector.swift
+++ b/Modules/Timer/Timer/Running/RunningTimeEntrySelector.swift
@@ -1,19 +1,21 @@
 import Models
 
-let runningTimeEntryViewModelSelector: (RunningTimeEntryState) -> TimeEntryViewModel? = { state in
+let runningTimeEntry: (TimeLogEntities) -> TimeEntryViewModel? = { state in
 
-    guard let timeEntry = state.entities.timeEntries.values.first(where: { timeEntry -> Bool in
+    guard let timeEntry = state.timeEntries.values.first(where: { timeEntry -> Bool in
             timeEntry.duration == nil
         })
     else { return nil }
 
-    let project = state.entities.getProject(timeEntry.projectId)
+    let project = state.getProject(timeEntry.projectId)
 
     return TimeEntryViewModel(
         timeEntry: timeEntry,
         project: project,
-        client: state.entities.getClient(project?.clientId),
-        task: state.entities.getTask(timeEntry.taskId),
-        tags: timeEntry.tagIds.compactMap(state.entities.getTag)
+        client: state.getClient(project?.clientId),
+        task: state.getTask(timeEntry.taskId),
+        tags: timeEntry.tagIds.compactMap(state.getTag)
     )
 }
+
+let runningTimeEntryViewModelSelector: (RunningTimeEntryState) -> TimeEntryViewModel? = { state in runningTimeEntry(state.entities) }

--- a/Modules/Timer/Timer/Running/RunningTimeEntryState.swift
+++ b/Modules/Timer/Timer/Running/RunningTimeEntryState.swift
@@ -5,7 +5,6 @@ import Utils
 public struct RunningTimeEntryState: Equatable {
     var user: Loadable<User>
     var entities: TimeLogEntities
-    var editableTimeEntry: EditableTimeEntry?
 
     var runningTimeEntry: TimeEntry? {
         entities.timeEntries.values.first(where: { timeEntry -> Bool in

--- a/Modules/Timer/Timer/StartEdit/StartEditSelector.swift
+++ b/Modules/Timer/Timer/StartEdit/StartEditSelector.swift
@@ -1,5 +1,0 @@
-import Models
-
-let shouldShowEditView: (StartEditState) -> Bool = { state in
-    return state.editableTimeEntry != nil
-}

--- a/Modules/Timer/Timer/StartEdit/StartEditState.swift
+++ b/Modules/Timer/Timer/StartEdit/StartEditState.swift
@@ -4,8 +4,8 @@ import Utils
 
 public struct StartEditState: Equatable {
     var entities: TimeLogEntities
-    var editableTimeEntry: EditableTimeEntry?
-    var autocompleteSuggestions: [AutocompleteSuggestion]
-    var dateTimePickMode: DateTimePickMode
-    var cursorPosition: Int
-}
+    var editableTimeEntry: EditableTimeEntry
+
+    internal var autocompleteSuggestions: [AutocompleteSuggestion] = []
+    internal var dateTimePickMode: DateTimePickMode = .none
+    internal var cursorPosition: Int = 0}

--- a/Modules/Timer/Timer/StartEdit/StartEditState.swift
+++ b/Modules/Timer/Timer/StartEdit/StartEditState.swift
@@ -3,7 +3,6 @@ import Models
 import Utils
 
 public struct StartEditState: Equatable {
-    var user: Loadable<User>
     var entities: TimeLogEntities
     var editableTimeEntry: EditableTimeEntry?
     var autocompleteSuggestions: [AutocompleteSuggestion]

--- a/Modules/Timer/Timer/StartEdit/Views/StartEditBottomSheet.swift
+++ b/Modules/Timer/Timer/StartEdit/Views/StartEditBottomSheet.swift
@@ -63,12 +63,6 @@ class StartEditBottomSheet<ContainedView: UIViewController>: UIViewController, U
             .subscribe(onNext: keyboardWillChange(intersectionHeight:))
             .disposed(by: disposeBag)
 
-        store.select(shouldShowEditView)
-            .drive(onNext: { [weak self] shouldShowEditView in
-                shouldShowEditView ? self?.show() : self?.hide()
-            })
-            .disposed(by: disposeBag)
-
         let navigationController = UINavigationController(rootViewController: containedViewController)
         navigationController.navigationBar.isHidden = true
 
@@ -112,13 +106,13 @@ class StartEditBottomSheet<ContainedView: UIViewController>: UIViewController, U
         layout()
     }
 
-    private func hide() {
+    func hide() {
         state = .hidden
         containedViewController.loseFocus()
         containedViewController.resignFirstResponder()
     }
 
-    private func show() {
+    func show() {
         state = .partial
         containedViewController.focus()
         UIImpactFeedbackGenerator(style: .light).impactOccurred()

--- a/Modules/Timer/Timer/TimeEntriesLog/TimeEntriesLogReducer.swift
+++ b/Modules/Timer/Timer/TimeEntriesLog/TimeEntriesLogReducer.swift
@@ -28,17 +28,6 @@ func createTimeEntriesLogReducer(
                 return [continueTimeEntry(repository, time: time, timeEntry: state.entities.timeEntries[timeEntryId]!)]
             }
 
-        case let .timeEntryTapped(timeEntryId):
-            state.editableTimeEntry = EditableTimeEntry.fromSingle(state.entities.timeEntries[timeEntryId]!)
-            return []
-
-        case let .timeEntryGroupTapped(timeEntryIds):
-            state.editableTimeEntry = EditableTimeEntry.fromGroup(
-                ids: timeEntryIds,
-                groupSample: state.entities.timeEntries[timeEntryIds.first!]!
-            )
-            return []
-
         case let .toggleTimeEntryGroupTapped(groupId):
             if state.expandedGroups.contains(groupId) {
                  state.expandedGroups.remove(groupId)
@@ -84,6 +73,9 @@ func createTimeEntriesLogReducer(
             
         case .undoButtonTapped:
             state.entriesPendingDeletion.removeAll()
+            return []
+
+        case .timeEntryTapped, .timeEntryGroupTapped:
             return []
         }
     }

--- a/Modules/Timer/Timer/TimeEntriesLog/TimeEntriesLogState.swift
+++ b/Modules/Timer/Timer/TimeEntriesLog/TimeEntriesLogState.swift
@@ -4,7 +4,13 @@ import Utils
 
 public struct TimeEntriesLogState: Equatable {
     var entities: TimeLogEntities
-    var expandedGroups: Set<Int>
-    var editableTimeEntry: EditableTimeEntry?
-    var entriesPendingDeletion = Set<Int64>()
+
+    internal var expandedGroups: Set<Int> = Set<Int>()
+    internal var entriesPendingDeletion = Set<Int64>()
+
+//    var editableTimeEntry: EditableTimeEntry?
+
+    public init(entities: TimeLogEntities) {
+        self.entities = entities
+    }
 }

--- a/Modules/Timer/Timer/TimerFeature.swift
+++ b/Modules/Timer/Timer/TimerFeature.swift
@@ -5,6 +5,7 @@ import OtherServices
 
 public func createTimerReducer(repository: Repository, time: Time, schedulerProvider: SchedulerProvider) -> Reducer<TimerState, TimerAction> {
     return combine(
+        timerReducer,
         createTimeEntriesLogReducer(repository: repository, time: time, schedulerProvider: schedulerProvider)
             .pullback(state: \.timeLogState, action: \.timeLog),
         createStartEditReducer(repository: repository, time: time)

--- a/Modules/Timer/Timer/TimerFeature.swift
+++ b/Modules/Timer/Timer/TimerFeature.swift
@@ -9,6 +9,7 @@ public func createTimerReducer(repository: Repository, time: Time, schedulerProv
         createTimeEntriesLogReducer(repository: repository, time: time, schedulerProvider: schedulerProvider)
             .pullback(state: \.timeLogState, action: \.timeLog),
         createStartEditReducer(repository: repository, time: time)
+            .optional
             .pullback(state: \.startEditState, action: \.startEdit),
         createRunningTimeEntryReducer(repository: repository, time: time)
             .pullback(state: \.runningTimeEntryState, action: \.runningTimeEntry)
@@ -41,7 +42,7 @@ public class TimerFeature: BaseFeature<TimerState, TimerAction> {
                },
                .startEdit: StartEditFeature(time: time)
                    .view { $0.view(
-                       state: { $0.startEditState },
+                       state: { $0.startEditState! },
                        action: { TimerAction.startEdit($0) })
                },
                .runningTimeEntry: RunningTimeEntryFeature()
@@ -64,8 +65,9 @@ public class TimerFeature: BaseFeature<TimerState, TimerAction> {
             store: store,
             timeLogCoordinator: features[.timeEntriesLog]!.mainCoordinator(store: store) as! TimeEntriesLogCoordinator,
             startEditCoordinator: features[.startEdit]!.mainCoordinator(store: store) as! StartEditCoordinator,
-            runningTimeEntryCoordinator: features[.runningTimeEntry]!.mainCoordinator(store: store) as! RunningTimeEntryCoordinator,
-            projectCoordinator: features[.project]!.mainCoordinator(store: store) as! ProjectCoordinator
+            runningTimeEntryCoordinator: features[.runningTimeEntry]!.mainCoordinator(store: store) as! RunningTimeEntryCoordinator
+//            ,
+//            projectCoordinator: features[.project]!.mainCoordinator(store: store) as! ProjectCoordinator
         )
     }
     // swiftlint:enable force_cast

--- a/Modules/Timer/Timer/TimerFeature.swift
+++ b/Modules/Timer/Timer/TimerFeature.swift
@@ -11,9 +11,10 @@ public func createTimerReducer(repository: Repository, time: Time, schedulerProv
         createStartEditReducer(repository: repository, time: time)
             .pullback(state: \.startEditState, action: \.startEdit),
         createRunningTimeEntryReducer(repository: repository, time: time)
-            .pullback(state: \.runningTimeEntryState, action: \.runningTimeEntry),
-        createProjectReducer(repository: repository)
-            .pullback(state: \.projectState, action: \.project)
+            .pullback(state: \.runningTimeEntryState, action: \.runningTimeEntry)
+//        ,
+//        createProjectReducer(repository: repository)
+//            .pullback(state: \.projectState, action: \.project)
     )
 }
 
@@ -47,12 +48,13 @@ public class TimerFeature: BaseFeature<TimerState, TimerAction> {
                    .view { $0.view(
                        state: { $0.runningTimeEntryState },
                        action: { TimerAction.runningTimeEntry($0) })
-               },
-               .project: ProjectFeature()
-                   .view { $0.view(
-                       state: { $0.projectState },
-                       action: { TimerAction.project($0) })
                }
+//            ,
+//               .project: ProjectFeature()
+//                   .view { $0.view(
+//                       state: { $0.projectState },
+//                       action: { TimerAction.project($0) })
+//               }
            ]
     }
 

--- a/Modules/TogglTrack/TogglTrack/AnalyticsReducer.swift
+++ b/Modules/TogglTrack/TogglTrack/AnalyticsReducer.swift
@@ -37,7 +37,7 @@ extension StartEditAction {
             return .editViewClosed(.close)
         case .doneButtonTapped:
             return .editViewClosed(
-                state.localTimerState.isEditingGroup() ? .groupSave : .save
+                state.timerState.isEditingGroup() ? .groupSave : .save
             )
         default:
             return nil

--- a/Modules/TogglTrack/TogglTrack/App/AppState.swift
+++ b/Modules/TogglTrack/TogglTrack/App/AppState.swift
@@ -10,8 +10,13 @@ public struct AppState {
     public var user: Loadable<User> = .nothing
     public var entities: TimeLogEntities =  TimeLogEntities()
     
-    public var localOnboardingState: LocalOnboardingState = LocalOnboardingState()
-    public var localTimerState: LocalTimerState = LocalTimerState()
+    private var _onboardingState: OnboardingState
+    private var _timerState: TimerState
+
+    init() {
+        _onboardingState = OnboardingState(user: user, route: route)
+        _timerState = TimerState(user: user, entities: entities)
+    }
 }
 
 // Module specific states
@@ -32,32 +37,29 @@ extension AppState {
     
     var onboardingState: OnboardingState {
         get {
-            OnboardingState(
-                user: user,
-                route: route,
-                localOnboardingState: localOnboardingState
-            )
+            var copy = _onboardingState
+            copy.route = route
+            copy.user = user
+            return copy
         }
         set {
+            _onboardingState = newValue
             user = newValue.user
             route = newValue.route
-            localOnboardingState = newValue.localOnboardingState
         }
     }
     
     var timerState: TimerState {
         get {
-            TimerState(
-                user: user,
-                entities: entities,
-                localTimerState: localTimerState
-            )
+            var copy = _timerState
+            copy.entities = entities
+            copy.user = user
+            return copy
         }
-        
         set {
-            user = newValue.user
+            _timerState = newValue
             entities = newValue.entities
-            localTimerState = newValue.localTimerState
+            user = newValue.user
         }
     }
 }


### PR DESCRIPTION
### Summary
This is a draft so we can further discussed what's described [here](https://github.com/toggl/mobile-discussions/issues/65).

### Technical considerations
The PR basically involves three things, if you read the commits one by one is easy to understand:
- Change the way we deal with local state by using a private backing property
- Allow for optional state and make StartEditState optional, then use the `optional` operator on reducers.
- Make the view controller or coordinator of the start edit view deal with this. THIS IS STILL PENDING.

The optional part is taken from [here](https://github.com/pointfreeco/swift-composable-architecture/blob/master/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-OptionalState.swift). It's SwiftUI so they deal with the view being optional with a `IfLetStore`, which we can't do, so that's the pending part, but it wouldn't be much complicated to do something equivalent for UIKit.

NOTE: The PR as it is right now doesn't work! (it needs the 3rd point described up there)

The crash happens [here](https://github.com/toggl/ios/pull/257/files#diff-b3ab72517359c1f70e93b5e63242567aR45) because that state can be nil (and it's nil at the beginning). So we need to find a way so it only attempts to "view" that store when that piece of state is not nil.

## Merge permissions
Don't. This is just a draft for discussion.
